### PR TITLE
Update puppet.py

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -156,17 +156,19 @@ def run(*args, **kwargs):
     '''
     _check_puppet()
     puppet = _Puppet()
-
-    if args:
+    
+    # new args tuple to filter out agent/apply for _Puppet.arguments()     
+    buildargs = ()
+    for arg in range(len(args)):
         # based on puppet documentation action must come first. making the same
         # assertion. need to ensure the list of supported cmds here matches
         # those defined in _Puppet.arguments()
-        if args[0] in ['agent', 'apply']:
-            puppet.subcmd = args[0]
-            puppet.arguments(args[1:])
-    else:
-        # args will exist as an empty list even if none have been provided
-        puppet.arguments(args)
+        if args[arg] in ['agent', 'apply']:
+            puppet.subcmd = args[arg]
+        else:
+            buildargs += (args[arg],)
+    # args will exist as an empty list even if none have been provided
+    puppet.arguments(buildargs)
 
     puppet.kwargs.update(salt.utils.clean_kwargs(**kwargs))
 


### PR DESCRIPTION
Update that fixes #28692 where puppet.noop results in an empty puppet run or when providing arguments to puppet.run without setting agent as the first argument results in an empty puppet run.
